### PR TITLE
feat: inference timer

### DIFF
--- a/data_utils/topk_timer.py
+++ b/data_utils/topk_timer.py
@@ -1,0 +1,31 @@
+from inference import *
+import pandas as pd
+import json
+from contextlib import contextmanager
+import time
+import numpy as np
+model, tokenizer = load_model()
+times = []
+"""
+top k 별 시간 측정을 위한 코드입니다
+"""
+
+@contextmanager
+def timer(name):
+    t0 = time.time()
+    yield
+    times.append(time.time() - t0)
+
+
+def main():
+    test_queries = list(pd.read_csv("/opt/ml/input/final-project-level3-nlp-09/data/test.csv")["question"])
+    result = []
+    for query in test_queries:
+        with timer(None):
+            result.append([res[0]["text"] for res in run_mrc(None, None, None, None, tokenizer, model, query)])
+    with open('../data/result_top1.json', 'w', encoding='utf-8') as f:
+        json.dump(result, f, ensure_ascii=False)
+    nptimes = np.array(times)
+    print(np.mean(nptimes), np.std(nptimes))
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
테스트 데이터셋이 시스템에서 질문 하나하나 받았을 때 질문 하나당 평균적으로 얼마만큼의 인퍼런스 타임이 소모되는지 확인하기 위해 질문을 배치에 넣는 것이 아닌 하나하나 넣어서 시간을 측정하는 파이썬 파일을 제작
인퍼런스 타임 측정 결과
|top-k| mean|std|
|---|---|---|
|top 1 | 1.0473295217984682 | 0.43389250966604415|
|top 2 | 1.1825725769067739 | 0.44961710987768866|
|top 3 | 1.3017600650911207 | 0.4867471233250318|
|top 4 | 1.4376503399440221 | 0.5251557593614039|
|top 5 | 1.5526868584868196 | 0.5554239607391672|